### PR TITLE
Allow Setting Detection Delay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
 			}
 		},
 		"node_modules/@types/glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
 			"dev": true,
 			"dependencies": {
 				"@types/minimatch": "*",
@@ -35,15 +35,15 @@
 			}
 		},
 		"node_modules/@types/minimatch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "13.13.21",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz",
-			"integrity": "sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ==",
+			"version": "13.13.52",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+			"integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
 			"dev": true
 		},
 		"node_modules/@types/pcm-volume": {
@@ -56,9 +56,9 @@
 			}
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.49.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
-			"integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
+			"version": "1.79.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.79.0.tgz",
+			"integrity": "sha512-Tfowu2rSW8hVGbqzQLSPlOEiIOYYryTkgJ+chMecpYiJcnw9n0essvSiclnK+Qh/TcSVJHgaK4EMrQDZjZJ/Sw==",
 			"dev": true
 		},
 		"node_modules/ansi-styles": {
@@ -83,21 +83,39 @@
 			}
 		},
 		"node_modules/azure-devops-node-api": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-			"integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
+			"integrity": "sha512-XdiGPhrpaT5J8wdERRKs5g8E0Zy1pvOYTli7z9E8nmOn3YGp4FhtjhrOyFmX/8veWCwdI69mCHKJw6l+4J/bHA==",
 			"dev": true,
 			"dependencies": {
-				"os": "0.1.1",
-				"tunnel": "0.0.4",
-				"typed-rest-client": "1.2.0",
-				"underscore": "1.8.3"
+				"tunnel": "0.0.6",
+				"typed-rest-client": "^1.8.4"
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/bindings": {
 			"version": "1.5.0",
@@ -107,10 +125,21 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
@@ -120,6 +149,30 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
 			}
 		},
 		"node_modules/buffer-alloc": {
@@ -139,7 +192,7 @@
 		"node_modules/buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -148,7 +201,20 @@
 		"node_modules/buffer-fill": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+			"integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/chalk": {
 			"version": "2.4.2",
@@ -165,21 +231,48 @@
 			}
 		},
 		"node_modules/cheerio": {
-			"version": "1.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
 			"dev": true,
 			"dependencies": {
-				"css-select": "~1.2.0",
-				"dom-serializer": "~0.1.1",
-				"entities": "~1.1.1",
-				"htmlparser2": "^3.9.1",
-				"lodash": "^4.15.0",
-				"parse5": "^3.0.1"
+				"cheerio-select": "^2.1.0",
+				"dom-serializer": "^2.0.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"htmlparser2": "^8.0.1",
+				"parse5": "^7.0.0",
+				"parse5-htmlparser2-tree-adapter": "^7.0.0"
 			},
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
 			}
+		},
+		"node_modules/cheerio-select": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-select": "^5.1.0",
+				"css-what": "^6.1.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true
 		},
 		"node_modules/color-convert": {
 			"version": "1.9.3",
@@ -193,46 +286,55 @@
 		"node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
 		"node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"node_modules/css-select": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
 			"dev": true,
 			"dependencies": {
-				"boolbase": "~1.0.0",
-				"css-what": "2.1",
-				"domutils": "1.5.1",
-				"nth-check": "~1.0.1"
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/css-what": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
 			"dev": true,
 			"engines": {
-				"node": "*"
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -245,66 +347,143 @@
 				}
 			}
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/denodeify": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-			"integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+			"integrity": "sha512-KNTihKNmQENUZeKu5fzfpzRqR5S2VMp4gl9RFHiWzj9DfvYQPMJ6XHKNaQxaGCXwPk6y9yme3aUoaiAe+KX+vg==",
 			"dev": true
 		},
+		"node_modules/detect-libc": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/dom-serializer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
 			"dev": true,
 			"dependencies": {
-				"domelementtype": "^1.3.0",
-				"entities": "^1.1.1"
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
 			}
 		},
 		"node_modules/domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-			"dev": true
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			]
 		},
 		"node_modules/domhandler": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
 			"dev": true,
 			"dependencies": {
-				"domelementtype": "1"
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
 			}
 		},
 		"node_modules/domutils": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
 			"dev": true,
 			"dependencies": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.4.0"
 			}
 		},
 		"node_modules/entities": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-			"dev": true
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/fd-slicer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
 			"dev": true,
 			"dependencies": {
 				"pend": "~1.2.0"
@@ -315,20 +494,53 @@
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+			"integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+			"dev": true
 		},
 		"node_modules/glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			},
@@ -339,33 +551,106 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
 		"node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
 		},
-		"node_modules/htmlparser2": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+		"node_modules/has-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
 			"dev": true,
 			"dependencies": {
-				"domelementtype": "^1.3.1",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.1.1"
+				"lru-cache": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
+		},
+		"node_modules/htmlparser2": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"entities": "^4.4.0"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -375,6 +660,23 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
+		},
+		"node_modules/keytar": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+			"integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"node-addon-api": "^4.3.0",
+				"prebuild-install": "^7.0.1"
+			}
 		},
 		"node_modules/leven": {
 			"version": "3.1.0",
@@ -395,10 +697,22 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
+		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/markdown-it": {
 			"version": "10.0.0",
@@ -425,7 +739,7 @@
 		"node_modules/mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
 			"dev": true
 		},
 		"node_modules/mime": {
@@ -440,16 +754,43 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true
 		},
 		"node_modules/ms": {
 			"version": "2.1.2",
@@ -462,33 +803,78 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
-		"node_modules/nth-check": {
+		"node_modules/napi-build-utils": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+			"dev": true
+		},
+		"node_modules/node-abi": {
+			"version": "3.45.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
+			"integrity": "sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==",
 			"dev": true,
 			"dependencies": {
-				"boolbase": "~1.0.0"
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/node-abi/node_modules/semver": {
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+			"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/node-addon-api": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+			"dev": true
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dependencies": {
 				"wrappy": "1"
 			}
 		},
-		"node_modules/os": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-			"integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=",
-			"dev": true
-		},
 		"node_modules/os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -497,7 +883,7 @@
 		"node_modules/os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -516,25 +902,41 @@
 		"node_modules/parse-semver": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
-			"integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
+			"integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
 			"dev": true,
 			"dependencies": {
 				"semver": "^5.1.0"
 			}
 		},
 		"node_modules/parse5": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
 			"dev": true,
 			"dependencies": {
-				"@types/node": "*"
+				"entities": "^4.4.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+			"dev": true,
+			"dependencies": {
+				"domhandler": "^5.0.2",
+				"parse5": "^7.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -550,13 +952,79 @@
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
 			"dev": true
+		},
+		"node_modules/prebuild-install": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+			"dev": true,
+			"dependencies": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^1.0.1",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			},
+			"bin": {
+				"prebuild-install": "bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.11.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+			"integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+			"dev": true,
+			"dependencies": {
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
 		},
 		"node_modules/read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
 			"dev": true,
 			"dependencies": {
 				"mute-stream": "~0.0.4"
@@ -566,9 +1034,9 @@
 			}
 		},
 		"node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -577,6 +1045,21 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -599,6 +1082,12 @@
 				}
 			]
 		},
+		"node_modules/sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
 		"node_modules/semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -608,10 +1097,69 @@
 				"semver": "bin/semver"
 			}
 		},
+		"node_modules/side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"node_modules/speaker": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/speaker/-/speaker-0.5.2.tgz",
-			"integrity": "sha512-5jGAnNPhg1NSf2d8OAtmJsZUHtlK4zqvS6esyNXs5/+30sBNnjqO0XViVVUlXWynUL2rEWUxn/5a2kTduPpsjA==",
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/speaker/-/speaker-0.5.4.tgz",
+			"integrity": "sha512-0I35CJGgqU1rd/a3qVysR5gLlG+8QlzJcPAEnYvT0BLfuLdJ7JNdlQHwbh7ETNcXDXbzm2O148GEAoAER54Dvw==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"bindings": "^1.3.0",
@@ -625,7 +1173,7 @@
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true
 		},
 		"node_modules/string_decoder": {
@@ -635,6 +1183,15 @@
 			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/supports-color": {
@@ -649,41 +1206,82 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/tmp": {
-			"version": "0.0.29",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-			"integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+		"node_modules/tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
 			"dev": true,
 			"dependencies": {
-				"os-tmpdir": "~1.0.1"
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
 			},
 			"engines": {
-				"node": ">=0.4.0"
+				"node": ">=6"
+			}
+		},
+		"node_modules/tmp": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+			"dev": true,
+			"dependencies": {
+				"rimraf": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8.17.0"
 			}
 		},
 		"node_modules/tunnel": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-			"integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
 			}
 		},
-		"node_modules/typed-rest-client": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-			"integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
 			"dev": true,
 			"dependencies": {
-				"tunnel": "0.0.4",
-				"underscore": "1.8.3"
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/typed-rest-client": {
+			"version": "1.8.9",
+			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
+			"integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+			"dev": true,
+			"dependencies": {
+				"qs": "^6.9.1",
+				"tunnel": "0.0.6",
+				"underscore": "^1.12.1"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -700,36 +1298,38 @@
 			"dev": true
 		},
 		"node_modules/underscore": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
 			"dev": true
 		},
 		"node_modules/url-join": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-			"integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
+			"integrity": "sha512-zz1wZk4Lb5PTVwZ3HWDmm8XnlPvmOof6/fjdDPA5yBrUcbtV64U6bV832Zf1BtU2WkBBWaUT46wCs+l0HP5nhg==",
 			"dev": true
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
 		},
 		"node_modules/vsce": {
-			"version": "1.79.5",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.79.5.tgz",
-			"integrity": "sha512-KZFOthGwxWFwoGqwrkzfTfyCZGuniTofnJ1a/dCzQ2HP93u1UuCKrTQyGT+SuGHu8sNqdBYNe0hb9GC3qCN7fg==",
+			"version": "1.103.1",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.103.1.tgz",
+			"integrity": "sha512-98oKQKKRp7J/vTIk1cuzom5cezZpYpRHs3WlySdsrTCrAEipB/HvaPTc4VZ3hGZHzHXS9P5p2L0IllntJeXwiQ==",
 			"deprecated": "vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.",
 			"dev": true,
 			"dependencies": {
-				"azure-devops-node-api": "^7.2.0",
+				"azure-devops-node-api": "^11.0.1",
 				"chalk": "^2.4.2",
-				"cheerio": "^1.0.0-rc.1",
-				"commander": "^2.8.1",
+				"cheerio": "^1.0.0-rc.9",
+				"commander": "^6.1.0",
 				"denodeify": "^1.2.1",
 				"glob": "^7.0.6",
+				"hosted-git-info": "^4.0.2",
+				"keytar": "^7.7.0",
 				"leven": "^3.1.0",
 				"lodash": "^4.17.15",
 				"markdown-it": "^10.0.0",
@@ -739,28 +1339,57 @@
 				"parse-semver": "^1.1.1",
 				"read": "^1.0.7",
 				"semver": "^5.1.0",
-				"tmp": "0.0.29",
-				"typed-rest-client": "1.2.0",
+				"tmp": "^0.2.1",
+				"typed-rest-client": "^1.8.4",
 				"url-join": "^1.1.0",
+				"xml2js": "^0.4.23",
 				"yauzl": "^2.3.1",
 				"yazl": "^2.2.2"
 			},
 			"bin": {
-				"vsce": "out/vsce"
+				"vsce": "vsce"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+		},
+		"node_modules/xml2js": {
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"dev": true,
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/yauzl": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
 			"dev": true,
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,294 +1,348 @@
 {
 	"name": "hotheaded-vscode",
-	"version": "1.1.0",
-	"lockfileVersion": 1,
+	"version": "1.1.2",
+	"lockfileVersion": 3,
 	"requires": true,
-	"dependencies": {
-		"@types/glob": {
+	"packages": {
+		"": {
+			"name": "hotheaded-vscode",
+			"version": "1.1.2",
+			"dependencies": {
+				"glob": "^7.1.6",
+				"speaker": "^0.5.2"
+			},
+			"devDependencies": {
+				"@types/glob": "^7.1.3",
+				"@types/node": "^13.13.21",
+				"@types/vscode": "^1.46.0",
+				"typescript": "^3.9.7",
+				"vsce": "^1.79.5"
+			},
+			"engines": {
+				"vscode": "^1.46.0"
+			}
+		},
+		"node_modules/@types/glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
 		},
-		"@types/minimatch": {
+		"node_modules/@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
 			"dev": true
 		},
-		"@types/node": {
+		"node_modules/@types/node": {
 			"version": "13.13.21",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz",
 			"integrity": "sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ==",
 			"dev": true
 		},
-		"@types/vscode": {
+		"node_modules/@types/vscode": {
 			"version": "1.49.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
 			"integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
 			"dev": true
 		},
-		"ansi-styles": {
+		"node_modules/ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
-		"argparse": {
+		"node_modules/argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
 		},
-		"azure-devops-node-api": {
+		"node_modules/azure-devops-node-api": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
 			"integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"os": "0.1.1",
 				"tunnel": "0.0.4",
 				"typed-rest-client": "1.2.0",
 				"underscore": "1.8.3"
 			}
 		},
-		"balanced-match": {
+		"node_modules/balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
-		"bindings": {
+		"node_modules/bindings": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
+			"dependencies": {
 				"file-uri-to-path": "1.0.0"
 			}
 		},
-		"boolbase": {
+		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
 			"dev": true
 		},
-		"brace-expansion": {
+		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"requires": {
+			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
-		"buffer-alloc": {
+		"node_modules/buffer-alloc": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
 			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"requires": {
+			"dependencies": {
 				"buffer-alloc-unsafe": "^1.1.0",
 				"buffer-fill": "^1.0.0"
 			}
 		},
-		"buffer-alloc-unsafe": {
+		"node_modules/buffer-alloc-unsafe": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
 			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
 		},
-		"buffer-crc32": {
+		"node_modules/buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
 		},
-		"buffer-fill": {
+		"node_modules/buffer-fill": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
 			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
 		},
-		"chalk": {
+		"node_modules/chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
-		"cheerio": {
+		"node_modules/cheerio": {
 			"version": "1.0.0-rc.3",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
 			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"css-select": "~1.2.0",
 				"dom-serializer": "~0.1.1",
 				"entities": "~1.1.1",
 				"htmlparser2": "^3.9.1",
 				"lodash": "^4.15.0",
 				"parse5": "^3.0.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
-		"color-convert": {
+		"node_modules/color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"color-name": "1.1.3"
 			}
 		},
-		"color-name": {
+		"node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
-		"commander": {
+		"node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
-		"concat-map": {
+		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
-		"css-select": {
+		"node_modules/css-select": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"boolbase": "~1.0.0",
 				"css-what": "2.1",
 				"domutils": "1.5.1",
 				"nth-check": "~1.0.1"
 			}
 		},
-		"css-what": {
+		"node_modules/css-what": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
 			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
 		},
-		"debug": {
+		"node_modules/debug": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
 			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-			"requires": {
+			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"dependencies": {
 				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
-		"denodeify": {
+		"node_modules/denodeify": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
 			"integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
 			"dev": true
 		},
-		"dom-serializer": {
+		"node_modules/dom-serializer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
 			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"domelementtype": "^1.3.0",
 				"entities": "^1.1.1"
 			}
 		},
-		"domelementtype": {
+		"node_modules/domelementtype": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
 			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
 			"dev": true
 		},
-		"domhandler": {
+		"node_modules/domhandler": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
 			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"domelementtype": "1"
 			}
 		},
-		"domutils": {
+		"node_modules/domutils": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
 			}
 		},
-		"entities": {
+		"node_modules/entities": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
 			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
 			"dev": true
 		},
-		"escape-string-regexp": {
+		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
 		},
-		"fd-slicer": {
+		"node_modules/fd-slicer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
 			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"pend": "~1.2.0"
 			}
 		},
-		"file-uri-to-path": {
+		"node_modules/file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
-		"fs.realpath": {
+		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
-		"glob": {
+		"node_modules/glob": {
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"requires": {
+			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"has-flag": {
+		"node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"htmlparser2": {
+		"node_modules/htmlparser2": {
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
 			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"domelementtype": "^1.3.1",
 				"domhandler": "^2.3.0",
 				"domutils": "^1.5.1",
@@ -297,294 +351,360 @@
 				"readable-stream": "^3.1.1"
 			}
 		},
-		"inflight": {
+		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"requires": {
+			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
 			}
 		},
-		"inherits": {
+		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
-		"leven": {
+		"node_modules/leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
 			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"linkify-it": {
+		"node_modules/linkify-it": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
 			"integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"uc.micro": "^1.0.1"
 			}
 		},
-		"lodash": {
+		"node_modules/lodash": {
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 			"dev": true
 		},
-		"markdown-it": {
+		"node_modules/markdown-it": {
 			"version": "10.0.0",
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
 			"integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"argparse": "^1.0.7",
 				"entities": "~2.0.0",
 				"linkify-it": "^2.0.0",
 				"mdurl": "^1.0.1",
 				"uc.micro": "^1.0.5"
 			},
-			"dependencies": {
-				"entities": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-					"integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
-					"dev": true
-				}
+			"bin": {
+				"markdown-it": "bin/markdown-it.js"
 			}
 		},
-		"mdurl": {
+		"node_modules/markdown-it/node_modules/entities": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+			"integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+			"dev": true
+		},
+		"node_modules/mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
 			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
 			"dev": true
 		},
-		"mime": {
+		"node_modules/mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"minimatch": {
+		"node_modules/minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"requires": {
+			"dependencies": {
 				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
-		"ms": {
+		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"mute-stream": {
+		"node_modules/mute-stream": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
-		"nth-check": {
+		"node_modules/nth-check": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
 			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"boolbase": "~1.0.0"
 			}
 		},
-		"once": {
+		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
+			"dependencies": {
 				"wrappy": "1"
 			}
 		},
-		"os": {
+		"node_modules/os": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
 			"integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=",
 			"dev": true
 		},
-		"os-homedir": {
+		"node_modules/os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"os-tmpdir": {
+		"node_modules/os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"osenv": {
+		"node_modules/osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
 			}
 		},
-		"parse-semver": {
+		"node_modules/parse-semver": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
 			"integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"semver": "^5.1.0"
 			}
 		},
-		"parse5": {
+		"node_modules/parse5": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
 			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/node": "*"
 			}
 		},
-		"path-is-absolute": {
+		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"pend": {
+		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
 			"dev": true
 		},
-		"read": {
+		"node_modules/read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
 			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"mute-stream": "~0.0.4"
+			},
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
-		"readable-stream": {
+		"node_modules/readable-stream": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
 				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"safe-buffer": {
+		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
-		"semver": {
+		"node_modules/semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
 		},
-		"speaker": {
+		"node_modules/speaker": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/speaker/-/speaker-0.5.2.tgz",
 			"integrity": "sha512-5jGAnNPhg1NSf2d8OAtmJsZUHtlK4zqvS6esyNXs5/+30sBNnjqO0XViVVUlXWynUL2rEWUxn/5a2kTduPpsjA==",
-			"requires": {
+			"hasInstallScript": true,
+			"dependencies": {
 				"bindings": "^1.3.0",
 				"buffer-alloc": "^1.1.0",
 				"debug": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8.6"
 			}
 		},
-		"sprintf-js": {
+		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
-		"string_decoder": {
+		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
 		},
-		"supports-color": {
+		"node_modules/supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
-		"tmp": {
+		"node_modules/tmp": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
 			"integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"os-tmpdir": "~1.0.1"
+			},
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
-		"tunnel": {
+		"node_modules/tunnel": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
 			"integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+			}
 		},
-		"typed-rest-client": {
+		"node_modules/typed-rest-client": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
 			"integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"tunnel": "0.0.4",
 				"underscore": "1.8.3"
 			}
 		},
-		"typescript": {
+		"node_modules/typescript": {
 			"version": "3.9.7",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
 			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
 		},
-		"uc.micro": {
+		"node_modules/uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
 			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
 			"dev": true
 		},
-		"underscore": {
+		"node_modules/underscore": {
 			"version": "1.8.3",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
 			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
 			"dev": true
 		},
-		"url-join": {
+		"node_modules/url-join": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
 			"integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
 			"dev": true
 		},
-		"util-deprecate": {
+		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
 		},
-		"vsce": {
+		"node_modules/vsce": {
 			"version": "1.79.5",
 			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.79.5.tgz",
 			"integrity": "sha512-KZFOthGwxWFwoGqwrkzfTfyCZGuniTofnJ1a/dCzQ2HP93u1UuCKrTQyGT+SuGHu8sNqdBYNe0hb9GC3qCN7fg==",
+			"deprecated": "vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"azure-devops-node-api": "^7.2.0",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.1",
@@ -605,29 +725,35 @@
 				"url-join": "^1.1.0",
 				"yauzl": "^2.3.1",
 				"yazl": "^2.2.2"
+			},
+			"bin": {
+				"vsce": "out/vsce"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"wrappy": {
+		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
-		"yauzl": {
+		"node_modules/yauzl": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
 			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
 			}
 		},
-		"yazl": {
+		"node_modules/yazl": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
 			"integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"buffer-crc32": "~0.2.3"
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 					"type": "number",
 					"default": 0,
 					"description": "Maximum cooldown duration in milliseconds."
-        },
+				},
 				"hotheadedVSCode.voiceVolume": {
 					"type": "number",
 					"default": 1,

--- a/package.json
+++ b/package.json
@@ -1,57 +1,67 @@
 {
-	"name": "hotheaded-vscode",
-	"displayName": "Hotheaded VS Code",
-	"publisher": "89netraM",
-	"description": "Are red squiggly lines not enough? Do you wish for more of a kick when you make an error? Have VS Code scream at you whenever you type something that isn't correct.",
-	"icon": "assets/icon.png",
-	"extensionKind": [
-		"ui"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/89netraM/hotheaded-vscode.git"
-	},
-	"version": "1.1.2",
-	"engines": {
-		"vscode": "^1.46.0"
-	},
-	"categories": [
-		"Other"
-	],
-	"keywords": [
-		"meme",
-		"anime"
-	],
-	"activationEvents": [
-		"onStartupFinished"
-	],
-	"contributes": {
-		"configuration": {
-			"title": "Hotheaded VS Code",
-			"properties": {
-				"hotheadedVSCode.voiceLineGlob": {
-					"type": "string",
-					"default": null,
-					"markdownDescription": "A glob targeting some uncompressed sounds files (`.wav` etc.). Leave blank for built-in voice lines.  \nRestart required."
-				}
-			}
-		}
-	},
-	"main": "./out/extension.js",
-	"scripts": {
-		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./"
-	},
-	"devDependencies": {
-		"@types/glob": "^7.1.3",
-		"@types/node": "^13.13.21",
-		"@types/vscode": "^1.46.0",
-		"typescript": "^3.9.7",
-		"vsce": "^1.79.5"
-	},
-	"dependencies": {
-		"glob": "^7.1.6",
-		"speaker": "^0.5.2"
-	}
+  "name": "hotheaded-vscode",
+  "displayName": "Hotheaded VS Code",
+  "publisher": "89netraM",
+  "description": "Are red squiggly lines not enough? Do you wish for more of a kick when you make an error? Have VS Code scream at you whenever you type something that isn't correct.",
+  "icon": "assets/icon.png",
+  "extensionKind": [
+    "ui"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/89netraM/hotheaded-vscode.git"
+  },
+  "version": "1.1.2",
+  "engines": {
+    "vscode": "^1.46.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    "meme",
+    "anime"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "contributes": {
+    "configuration": {
+      "title": "Hotheaded VS Code",
+      "properties": {
+        "hotheadedVSCode.cooldownDurationMin": {
+          "type": "number",
+          "default": 5000,
+          "description": "Minimum cooldown duration in milliseconds."
+        },
+        "hotheadedVSCode.cooldownDurationMax": {
+          "type": "number",
+          "default": 10000,
+          "description": "Maximum cooldown duration in milliseconds."
+        },
+        "hotheadedVSCode.voiceLineGlob": {
+          "type": "string",
+          "default": null,
+          "markdownDescription": "A glob targeting some uncompressed sounds files (`.wav` etc.). Leave blank for built-in voice lines.  \nRestart required."
+        }
+      }
+    }
+  },
+  "main": "./out/extension.js",
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/glob": "^7.1.3",
+    "@types/node": "^13.13.21",
+    "@types/vscode": "^1.46.0",
+    "typescript": "^3.9.7",
+    "vsce": "^1.79.5"
+  },
+  "dependencies": {
+    "glob": "^7.1.6",
+    "speaker": "^0.5.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,15 +35,15 @@
 					"markdownDescription": "A glob targeting some uncompressed sounds files (`.wav` etc.). Leave blank for built-in voice lines.  \nRestart required."
 				},
 				"hotheadedVSCode.cooldownDurationMin": {
-          "type": "number",
-          "default": 0,
-          "description": "Minimum cooldown duration in milliseconds."
-        },
-        "hotheadedVSCode.cooldownDurationMax": {
-          "type": "number",
-          "default": 0,
-          "description": "Maximum cooldown duration in milliseconds."
-        }
+					"type": "number",
+					"default": 0,
+					"description": "Minimum cooldown duration in milliseconds."
+				},
+				"hotheadedVSCode.cooldownDurationMax": {
+					"type": "number",
+					"default": 0,
+					"description": "Maximum cooldown duration in milliseconds."
+				}
 			}
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
 				},
 				"hotheadedVSCode.cooldownDurationMin": {
           "type": "number",
-          "default": 5000,
+          "default": 0,
           "description": "Minimum cooldown duration in milliseconds."
         },
         "hotheadedVSCode.cooldownDurationMax": {
           "type": "number",
-          "default": 10000,
+          "default": 0,
           "description": "Maximum cooldown duration in milliseconds."
         }
 			}

--- a/package.json
+++ b/package.json
@@ -1,35 +1,40 @@
 {
-  "name": "hotheaded-vscode",
-  "displayName": "Hotheaded VS Code",
-  "publisher": "89netraM",
-  "description": "Are red squiggly lines not enough? Do you wish for more of a kick when you make an error? Have VS Code scream at you whenever you type something that isn't correct.",
-  "icon": "assets/icon.png",
-  "extensionKind": [
-    "ui"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/89netraM/hotheaded-vscode.git"
-  },
-  "version": "1.1.2",
-  "engines": {
-    "vscode": "^1.46.0"
-  },
-  "categories": [
-    "Other"
-  ],
-  "keywords": [
-    "meme",
-    "anime"
-  ],
-  "activationEvents": [
-    "onStartupFinished"
-  ],
-  "contributes": {
-    "configuration": {
-      "title": "Hotheaded VS Code",
-      "properties": {
-        "hotheadedVSCode.cooldownDurationMin": {
+	"name": "hotheaded-vscode",
+	"displayName": "Hotheaded VS Code",
+	"publisher": "89netraM",
+	"description": "Are red squiggly lines not enough? Do you wish for more of a kick when you make an error? Have VS Code scream at you whenever you type something that isn't correct.",
+	"icon": "assets/icon.png",
+	"extensionKind": [
+		"ui"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/89netraM/hotheaded-vscode.git"
+	},
+	"version": "1.1.2",
+	"engines": {
+		"vscode": "^1.46.0"
+	},
+	"categories": [
+		"Other"
+	],
+	"keywords": [
+		"meme",
+		"anime"
+	],
+	"activationEvents": [
+		"onStartupFinished"
+	],
+	"contributes": {
+		"configuration": {
+			"title": "Hotheaded VS Code",
+			"properties": {
+				"hotheadedVSCode.voiceLineGlob": {
+					"type": "string",
+					"default": null,
+					"markdownDescription": "A glob targeting some uncompressed sounds files (`.wav` etc.). Leave blank for built-in voice lines.  \nRestart required."
+				},
+				"hotheadedVSCode.cooldownDurationMin": {
           "type": "number",
           "default": 5000,
           "description": "Minimum cooldown duration in milliseconds."
@@ -38,30 +43,25 @@
           "type": "number",
           "default": 10000,
           "description": "Maximum cooldown duration in milliseconds."
-        },
-        "hotheadedVSCode.voiceLineGlob": {
-          "type": "string",
-          "default": null,
-          "markdownDescription": "A glob targeting some uncompressed sounds files (`.wav` etc.). Leave blank for built-in voice lines.  \nRestart required."
         }
-      }
-    }
-  },
-  "main": "./out/extension.js",
-  "scripts": {
-    "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./"
-  },
-  "devDependencies": {
-    "@types/glob": "^7.1.3",
-    "@types/node": "^13.13.21",
-    "@types/vscode": "^1.46.0",
-    "typescript": "^3.9.7",
-    "vsce": "^1.79.5"
-  },
-  "dependencies": {
-    "glob": "^7.1.6",
-    "speaker": "^0.5.2"
-  }
+			}
+		}
+	},
+	"main": "./out/extension.js",
+	"scripts": {
+		"vscode:prepublish": "npm run compile",
+		"compile": "tsc -p ./",
+		"watch": "tsc -watch -p ./"
+	},
+	"devDependencies": {
+		"@types/glob": "^7.1.3",
+		"@types/node": "^13.13.21",
+		"@types/vscode": "^1.46.0",
+		"typescript": "^3.9.7",
+		"vsce": "^1.79.5"
+	},
+	"dependencies": {
+		"glob": "^7.1.6",
+		"speaker": "^0.5.2"
+	}
 }

--- a/src/ErrorTracker.ts
+++ b/src/ErrorTracker.ts
@@ -1,51 +1,32 @@
-import {
-  DiagnosticChangeEvent,
-  Uri,
-  Diagnostic,
-  window,
-  workspace,
-  languages,
-  DiagnosticSeverity,
-  Range,
-  TextDocument,
-  Position,
-  TextEditor,
-} from "vscode";
+import { DiagnosticChangeEvent, Uri, Diagnostic, window, workspace, languages, DiagnosticSeverity, Range, TextDocument, Position, TextEditor } from "vscode";
 import { bash } from "./Basher";
 
 let cooldownTimer: NodeJS.Timeout | null = null;
 
 export function OnDidChangeDiagnostics(e: DiagnosticChangeEvent): void {
-  const activeTextEditor = window.activeTextEditor;
-  if (
-    activeTextEditor &&
-    e.uris.find((uri) => uri.path === activeTextEditor.document.uri.path)
-  ) {
-    const errors = errorsForFile(
-      activeTextEditor,
-      activeTextEditor.document.uri
-    );
-    if (errors.length > 0) {
-      if (errors.filter((d) => !sameAsPrevious(d)).length > 0) {
-        console.log("Error: ", errors);
+	const activeTextEditor = window.activeTextEditor;
+	if (
+		activeTextEditor && e.uris.find(uri => uri.path === activeTextEditor.document.uri.path)
+	) {
+		const errors = errorsForFile(activeTextEditor, activeTextEditor.document.uri);
+		if (errors.length > 0) {
+			if (errors.filter((d) => !sameAsPrevious(d)).length > 0) {
+				console.log("Error: ", errors);
         if (cooldownTimer === null) {
           bash();
           setPreviousError(errors[0]);
-
           const cooldownDuration = getRandomCooldownDuration();
-
           console.log(cooldownDuration);
-
           cooldownTimer = setTimeout(() => {
             cooldownTimer = null;
           }, cooldownDuration);
         }
-      }
-    } else {
-      console.log("No errors");
-      clearPreviousError();
-    }
-  }
+			}
+		} else {
+			console.log("No errors");
+			clearPreviousError();
+		}
+	}
 }
 
 function getRandomCooldownDuration(): number {
@@ -63,54 +44,43 @@ function getRandomCooldownDuration(): number {
 }
 
 function errorsForFile(editor: TextEditor, fileUri: Uri): Array<Diagnostic> {
-  return languages
-    .getDiagnostics(fileUri)
-    .filter(
-      (d) =>
-        d.severity === DiagnosticSeverity.Error && isErrorCurrent(editor, d)
-    );
+	return languages
+		.getDiagnostics(fileUri)
+		.filter(d => d.severity === DiagnosticSeverity.Error && isErrorCurrent(editor, d));
+
 }
 
-function textBetween(
-  document: TextDocument,
-  cursor: Position,
-  error: Range
-): string {
-  if (error.contains(cursor)) {
-    return "";
-  } else {
-    let start: Position;
-    let end: Position;
-    if (cursor.isBeforeOrEqual(error.start)) {
-      start = cursor;
-      end = error.start;
-    } else {
-      start = error.end;
-      end = cursor;
-    }
+function textBetween(document: TextDocument, cursor: Position, error: Range): string {
+	if (error.contains(cursor)) {
+		return "";
+	}
+	else {
+		let start: Position;
+		let end: Position;
+		if (cursor.isBeforeOrEqual(error.start)) {
+			start = cursor;
+			end = error.start;
+		}
+		else {
+			start = error.end;
+			end = cursor;
+		}
 
-    return document.getText(new Range(start, end));
-  }
+		return document.getText(new Range(start, end));
+	}
 }
 function isErrorCurrent(editor: TextEditor, error: Diagnostic): boolean {
-  const between = textBetween(
-    editor.document,
-    editor.selection.active,
-    error.range
-  );
-  return /^\s*$/.test(between);
+	const between = textBetween(editor.document, editor.selection.active, error.range);
+	return /^\s*$/.test(between);
 }
 
 let previousError: Diagnostic | null = null;
 function setPreviousError(error: Diagnostic): void {
-  previousError = error;
+	previousError = error;
 }
 function clearPreviousError(): void {
-  previousError = null;
+	previousError = null;
 }
 function sameAsPrevious(error: Diagnostic): boolean {
-  return (
-    previousError?.code === error.code &&
-    previousError?.range.end.line === error.range.end.line
-  );
+	return previousError?.code === error.code && previousError?.range.end.line === error.range.end.line;
 }

--- a/src/ErrorTracker.ts
+++ b/src/ErrorTracker.ts
@@ -11,15 +11,15 @@ export function OnDidChangeDiagnostics(e: DiagnosticChangeEvent): void {
 		if (errors.length > 0) {
 			if (errors.filter((d) => !sameAsPrevious(d)).length > 0) {
 				console.log("Error: ", errors);
-        if (cooldownTimer === null) {
-          bash();
-          setPreviousError(errors[0]);
-          const cooldownDuration = getRandomCooldownDuration();
-          console.log(cooldownDuration);
-          cooldownTimer = setTimeout(() => {
-            cooldownTimer = null;
-          }, cooldownDuration);
-        }
+				if (cooldownTimer === null) {
+					bash();
+					setPreviousError(errors[0]);
+					const cooldownDuration = getRandomCooldownDuration();
+					console.log(cooldownDuration);
+					cooldownTimer = setTimeout(() => {
+						cooldownTimer = null;
+					}, cooldownDuration);
+				}
 			}
 		} else {
 			console.log("No errors");
@@ -28,17 +28,17 @@ export function OnDidChangeDiagnostics(e: DiagnosticChangeEvent): void {
 	}
 }
 function getRandomCooldownDuration(): number {
-  const minDuration = workspace
-    .getConfiguration("hotheadedVSCode")
-    .get<number>("cooldownDurationMin") as number;
-  const maxDuration = workspace
-    .getConfiguration("hotheadedVSCode")
-    .get<number>("cooldownDurationMax") as number;
+	const minDuration = workspace
+		.getConfiguration("hotheadedVSCode")
+		.get<number>("cooldownDurationMin") as number;
+	const maxDuration = workspace
+		.getConfiguration("hotheadedVSCode")
+		.get<number>("cooldownDurationMax") as number;
 
-  const randomDuration = Math.floor(
-    Math.random() * (maxDuration - minDuration + 1) + minDuration
-  );
-  return randomDuration;
+	const randomDuration = Math.floor(
+		Math.random() * (maxDuration - minDuration + 1) + minDuration
+	);
+	return randomDuration;
 }
 function errorsForFile(editor: TextEditor, fileUri: Uri): Array<Diagnostic> {
 	return languages

--- a/src/ErrorTracker.ts
+++ b/src/ErrorTracker.ts
@@ -2,7 +2,6 @@ import { DiagnosticChangeEvent, Uri, Diagnostic, window, workspace, languages, D
 import { bash } from "./Basher";
 
 let cooldownTimer: NodeJS.Timeout | null = null;
-
 export function OnDidChangeDiagnostics(e: DiagnosticChangeEvent): void {
 	const activeTextEditor = window.activeTextEditor;
 	if (
@@ -28,7 +27,6 @@ export function OnDidChangeDiagnostics(e: DiagnosticChangeEvent): void {
 		}
 	}
 }
-
 function getRandomCooldownDuration(): number {
   const minDuration = workspace
     .getConfiguration("hotheadedVSCode")
@@ -42,12 +40,10 @@ function getRandomCooldownDuration(): number {
   );
   return randomDuration;
 }
-
 function errorsForFile(editor: TextEditor, fileUri: Uri): Array<Diagnostic> {
 	return languages
 		.getDiagnostics(fileUri)
 		.filter(d => d.severity === DiagnosticSeverity.Error && isErrorCurrent(editor, d));
-
 }
 
 function textBetween(document: TextDocument, cursor: Position, error: Range): string {

--- a/src/ErrorTracker.ts
+++ b/src/ErrorTracker.ts
@@ -1,61 +1,116 @@
-import { DiagnosticChangeEvent, Uri, Diagnostic, window, languages, DiagnosticSeverity, Range, TextDocument, Position, TextEditor } from "vscode";
+import {
+  DiagnosticChangeEvent,
+  Uri,
+  Diagnostic,
+  window,
+  workspace,
+  languages,
+  DiagnosticSeverity,
+  Range,
+  TextDocument,
+  Position,
+  TextEditor,
+} from "vscode";
 import { bash } from "./Basher";
 
+let cooldownTimer: NodeJS.Timeout | null = null;
+
 export function OnDidChangeDiagnostics(e: DiagnosticChangeEvent): void {
-	const activeTextEditor = window.activeTextEditor;
-	if (
-		activeTextEditor && e.uris.find(uri => uri.path === activeTextEditor.document.uri.path)
-	) {
-		const errors = errorsForFile(activeTextEditor, activeTextEditor.document.uri);
-		if (errors.length > 0) {
-			if (errors.filter((d) => !sameAsPrevious(d)).length > 0) {
-				console.log(errors);
-				bash();
-				setPreviousError(errors[0]);
-			}
-		} else {
-			console.log("No errors");
-			clearPreviousError();
-		}
-	}
+  const activeTextEditor = window.activeTextEditor;
+  if (
+    activeTextEditor &&
+    e.uris.find((uri) => uri.path === activeTextEditor.document.uri.path)
+  ) {
+    const errors = errorsForFile(
+      activeTextEditor,
+      activeTextEditor.document.uri
+    );
+    if (errors.length > 0) {
+      if (errors.filter((d) => !sameAsPrevious(d)).length > 0) {
+        console.log("Error: ", errors);
+        if (cooldownTimer === null) {
+          bash();
+          setPreviousError(errors[0]);
+
+          const cooldownDuration = getRandomCooldownDuration();
+
+          console.log(cooldownDuration);
+
+          cooldownTimer = setTimeout(() => {
+            cooldownTimer = null;
+          }, cooldownDuration);
+        }
+      }
+    } else {
+      console.log("No errors");
+      clearPreviousError();
+    }
+  }
 }
+
+function getRandomCooldownDuration(): number {
+  const minDuration = workspace
+    .getConfiguration("hotheadedVSCode")
+    .get<number>("cooldownDurationMin") as number;
+  const maxDuration = workspace
+    .getConfiguration("hotheadedVSCode")
+    .get<number>("cooldownDurationMax") as number;
+
+  const randomDuration = Math.floor(
+    Math.random() * (maxDuration - minDuration + 1) + minDuration
+  );
+  return randomDuration;
+}
+
 function errorsForFile(editor: TextEditor, fileUri: Uri): Array<Diagnostic> {
-	return languages
-		.getDiagnostics(fileUri)
-		.filter(d => d.severity === DiagnosticSeverity.Error && isErrorCurrent(editor, d));
+  return languages
+    .getDiagnostics(fileUri)
+    .filter(
+      (d) =>
+        d.severity === DiagnosticSeverity.Error && isErrorCurrent(editor, d)
+    );
 }
 
-function textBetween(document: TextDocument, cursor: Position, error: Range): string {
-	if (error.contains(cursor)) {
-		return "";
-	}
-	else {
-		let start: Position;
-		let end: Position;
-		if (cursor.isBeforeOrEqual(error.start)) {
-			start = cursor;
-			end = error.start;
-		}
-		else {
-			start = error.end;
-			end = cursor;
-		}
+function textBetween(
+  document: TextDocument,
+  cursor: Position,
+  error: Range
+): string {
+  if (error.contains(cursor)) {
+    return "";
+  } else {
+    let start: Position;
+    let end: Position;
+    if (cursor.isBeforeOrEqual(error.start)) {
+      start = cursor;
+      end = error.start;
+    } else {
+      start = error.end;
+      end = cursor;
+    }
 
-		return document.getText(new Range(start, end));
-	}
+    return document.getText(new Range(start, end));
+  }
 }
 function isErrorCurrent(editor: TextEditor, error: Diagnostic): boolean {
-	const between = textBetween(editor.document, editor.selection.active, error.range);
-	return /^\s*$/.test(between);
+  const between = textBetween(
+    editor.document,
+    editor.selection.active,
+    error.range
+  );
+  return /^\s*$/.test(between);
 }
 
 let previousError: Diagnostic | null = null;
 function setPreviousError(error: Diagnostic): void {
-	previousError = error;
+  previousError = error;
 }
 function clearPreviousError(): void {
-	previousError = null;
+  previousError = null;
 }
 function sameAsPrevious(error: Diagnostic): boolean {
-	return previousError?.code === error.code && previousError?.range.end.line === error.range.end.line;
+  return (
+    previousError?.code === error.code &&
+    previousError?.range.end.line === error.range.end.line
+  );
 }


### PR DESCRIPTION
This pull request addresses issue #12 and #10 by introducing a configurable detection delay for the extension. Users can now set a delay between a range to control the frequency at which the extension reacts to errors and voice lines are played.

I recommend a minimum cooldown duration of `600000` milliseconds (10 minutes) and a maximum of `3600000` (1 hour)  for really unexpected remainders of your failures **c:**